### PR TITLE
Open ancients optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ After a fresh ascend with an available clickable, start the speed run loop with 
 | ------ | -------- |
 <kbd>Ctrl+F1</kbd>       | Loop speed runs
 <kbd>Ctrl+F2</kbd>       | Start a deep run
+<kbd>Ctrl+F3</kbd>       | Open Ancient Optimizer
 <kbd>Pause</kbd>         | Pause/unpause the script
 <kbd>Alt+Pause</kbd>     | Abort active speed/deep runs and an initiated auto ascension
 <kbd>Shift+Pause</kbd>   | Do not start new speed/deep runs after finishing the current run and ascension

--- a/ch_sw1ft_bot.ahk
+++ b/ch_sw1ft_bot.ahk
@@ -129,6 +129,10 @@ return
 	deepRun()
 return
 
+^F3::
+	openAncientOptimizer()
+return
+
 ; Set previous ranger as re-gild target
 ^F6::
 	reGildRanger := reGildRanger > rangers.MinIndex() ? reGildRanger-1 : reGildRanger
@@ -524,15 +528,21 @@ lvlUp(seconds, buyUpgrades, button, stint, stints) {
 	stopMouseMonitoring()
 }
 
-save() {
+openSaveDialog() {
 	global
-	local fileName := "ch" . A_NowUTC . ".txt"
-	local newFileName := ""
 
 	clickPos(xSettings, ySettings)
 	sleep % zzz * 3
 	clickPos(xSave, ySave)
 	sleep % zzz * 4
+}
+
+save() {
+	global
+	local fileName := "ch" . A_NowUTC . ".txt"
+	local newFileName := ""
+
+	openSaveDialog()
 
 	; Change the file name...
 	if (saveMode = 1) {
@@ -551,6 +561,39 @@ save() {
 
 	sleep % zzz * 3
 	clickPos(xSettingsClose, ySettingsClose)
+}
+
+openAncientOptimizer() {
+	global
+
+	local templateFileName := "system\ancients_optimizer_loader.html"
+	FileRead, loaderSourceTemplate, %templateFileName%
+
+	local loaderFileName := A_Temp . "\ch_ao_" . A_NowUTC . ".html"
+	local file = FileOpen(loaderFileName, "w")
+	if !IsObject(file)
+	{
+		MsgBox % "Can't open " . loaderFileName . " for writing."
+		return
+	}
+
+	openSaveDialog()
+
+	; Abort saving. Clipboard is good enough
+	ControlSend,, {esc}, ahk_class %dialogBoxClass%
+
+	sleep % zzz * 3
+	clickPos(xSettingsClose, ySettingsClose)
+
+	; Write loader file
+	local loaderSource := StrReplace(loaderSourceTemplate, "#####SAVEGAME#####", Clipboard)
+
+    file.write(loaderSource)
+    file.Close()
+
+    Run, %loaderFileName%
+    sleep % zzz * 5
+    FileDelete, %loaderFileName%
 }
 
 ascend(autoYes:=false) {

--- a/system/ancients_optimizer_loader.html
+++ b/system/ancients_optimizer_loader.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>ClickerHeroes Ancients optimizer</title>
+    <script language="javascript">
+        function send_savegame() {
+            var iframe = document.getElementsByTagName('iframe')[0];
+
+            iframe.contentWindow.postMessage(document.getElementById('ch_savegame').innerHTML, iframe.src)
+        }
+    </script>
+    <style type="text/css">
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        iframe {
+            border: 0;
+            width: 100%;
+        }
+
+        html, body, iframe {
+            height: 100%;
+            overflow: hidden;
+        }
+
+        #ch_savegame {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+<textarea id="ch_savegame">
+#####SAVEGAME#####
+</textarea>
+<iframe id="ancientssoul" src="http://s3-us-west-2.amazonaws.com/clickerheroes/ancientssoul.html"
+        onload="send_savegame()"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
This PR introduces Ctrl-F3, which opens the ancient optimizer with the current game imported.

This feature needs a little update on the ancient optimizer. The following code must be executed in the onload handler of the page:

``` javascript
$(window).on("message", function(event) {
  $("#savedata").val(event.originalEvent.data);
  Import();
})
```

I will ask /u/rler to add this. Until then, this PR should not be merged
- [x] Ancient Optimizer is capable of receiving savegame
- [x] Check if everything is fine
