### PR TITLE
Show Relics before ascending

### DIFF
--- a/ch_sw1ft_bot.ahk
+++ b/ch_sw1ft_bot.ahk
@@ -562,6 +562,7 @@ ascend(autoYes:=false) {
 	if (autoYes) {
 		showWarningSplash(autoAscendDelay . " seconds till ASCENSION! (Abort with Alt+Pause)", autoAscendDelay)
 		if (exitThread) {
+			exitThread := false
 			showSplashAlways("Ascension aborted!")
 			exit
 		}

--- a/ch_sw1ft_bot.ahk
+++ b/ch_sw1ft_bot.ahk
@@ -560,11 +560,13 @@ ascend(autoYes:=false) {
 	local y := yAsc - extraClicks * buttonSize
 
 	if (autoYes) {
-		showWarningSplash(autoAscendDelay . " seconds till ASCENSION! (Abort with Alt+Pause)", autoAscendDelay)
-		if (exitThread) {
-			exitThread := false
-			showSplashAlways("Ascension aborted!")
-			exit
+		if(autoAscendDelay > 0) {
+			showWarningSplash(autoAscendDelay . " seconds till ASCENSION! (Abort with Alt+Pause)", autoAscendDelay)
+			if (exitThread) {
+				exitThread := false
+				showSplashAlways("Ascension aborted!")
+				exit
+			}
 		}
 	} else {
 		playWarningSound()
@@ -594,11 +596,30 @@ salvageJunkPile() {
 	global
 
 	switchToRelicTab()
-	if (autoAscend && screenShotRelics) {
-		clickPos(xRelic, yRelic) ; focus
-		screenShot()
-		clickPos(xRelic+100, yRelic) ; remove focus
+
+	if (autoAscend) {
+		if (screenShotRelics || displayRelicsDuration > 0) {
+			clickPos(xRelic, yRelic) ; focus
+		}
+
+		if (screenShotRelics) {
+			screenShot()
+		}
+
+		if (displayRelicsDuration > 0) {
+			showWarningSplash(displayRelicsDuration . " seconds till SALVATION! (Abort with Alt+Pause)", displayRelicsDuration)
+			if (exitThread) {
+				exitThread := false
+				showSplashAlways("Salvation aborted!")
+				exit
+			}
+		}
+
+		if (screenShotRelics || displayRelicsDuration > 0) {
+			clickPos(xRelic+100, yRelic) ; remove focus
+		}
 	}
+
 	clickPos(xSalvageJunk, ySalvageJunk)
 	sleep % zzz * 4
 	clickPos(xDestroyYes, yDestroyYes)

--- a/system/ch_bot_default_settings.ahk
+++ b/system/ch_bot_default_settings.ahk
@@ -31,7 +31,12 @@ hybridMode := false ; chain a deep run when the speed run finish
 ascDownClicks := 26 ; # of down clicks needed to get the ascension button center:ish (after a full speed run)
 
 autoAscend := false ; Warning! Set to true will both salvage relics and ascend without any user intervention!
+
+; Auto Ascend Warning Mode
+; The following two settings may replace each other or can just be used both
+; Set to 0 to disable completely
 autoAscendDelay := 10 ; warning timer (in seconds) before ascending
+displayRelicsDuration := 10 ; warning timer (in seconds) salvaging junk pile
 
 ; If you run the Steam client with autoAscend, you can screenshot every relic you salvage!
 screenShotRelics := false


### PR DESCRIPTION
This PR adds another configuration variable which may be used as an alternative to autoAscendDelay.

While autoAscend leaves the Heroes list intact which makes an easier continuation possible but hides the relic, displayRelicDuration shows the relic for a specified time, but (of course) resets the position of the heroes list. Of course both options can be used, too.

This PR also resets exitThread to false after aborting an ascension. This way the current speedrun will not abort when aborting an ascension.
