### PR TITLE
Wiggle mouse to prevent screen lock

### DIFF
--- a/ch_sw1ft_bot.ahk
+++ b/ch_sw1ft_bot.ahk
@@ -634,7 +634,11 @@ visionRun() {
 		zone := getCurrentZone()
 		t += 1
 		sleep 1000
-
+		
++		; Move the mouse pointer 1 pixel to the right of current location, then back (prevent screen lock):
++		MouseMove, 1, 0, 10, R
++		MouseMove, -1, 0, 10, R
++
 	} until zone > getEndZone() or readyToAscend
 
 	if (earlyGameMode) {


### PR DESCRIPTION
Moves the mouse pointer 1px right and left, prevents screen from locking / screensaver from activating.
